### PR TITLE
Deal with CESM history file times in more generic way

### DIFF
--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -93,7 +93,7 @@ def parse_cesm_history(file):
         with xr.open_dataset(file, chunks={}, decode_times=False) as ds:
             time = ds.cf['T'].name
             try:
-                time_bounds = ds.cf.get_bounds('time').name 
+                time_bounds = ds.cf.get_bounds('time').name
             except KeyError:
                 time_bounds = ''
             variables = [

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -92,13 +92,10 @@ def parse_cesm_history(file):
                 break
         with xr.open_dataset(file, chunks={}, decode_times=False) as ds:
             time = ds.cf['T'].name
-            
             try:
-                time_bounds = ds.cf.get_bounds('time').name
-                
+                time_bounds = ds.cf.get_bounds('time').name 
             except KeyError:
                 time_bounds = ''
-            
             variables = [
                 v
                 for v, da in ds.variables.items()

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -91,8 +91,14 @@ def parse_cesm_history(file):
                 info['date'] = z[-1].strip('.')
                 break
         with xr.open_dataset(file, chunks={}, decode_times=False) as ds:
-            time = ds.cf['time'].name
-            time_bounds = ds.cf.get_bounds('time').name
+            time = ds.cf['T'].name
+            
+            try:
+                time_bounds = ds.cf.get_bounds('time').name
+                
+            except KeyError:
+                time_bounds = ''
+            
             variables = [
                 v
                 for v, da in ds.variables.items()


### PR DESCRIPTION
Helps with #21 
* Changes use of `cf_xarray` time dimension call to use `T` instead of `time` to find time variable name
* Includes try-except block to grab time bound information, if it isn't there (as in CISM), feeds empty string which still allows searching for variables with time dimension, dropping time and time bound variables