### PR TITLE
Fix missing frequency in timeseries

### DIFF
--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -211,7 +211,7 @@ def parse_cesm_timeseries(file, user_streams_dict={}):
 
             except (KeyError, AttributeError):
                 warnings.warn('Using the default frequency definitions')
-
+                info['frequency'] = stream.frequency
             info['path'] = str(file)
         return info
 


### PR DESCRIPTION
Currently, the default frequency is not used in the CESM timeseries parser. This fixes that issue