### PR TITLE
Allow member_id to be optional

### DIFF
--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -85,7 +85,10 @@ def parse_date(date):
         return ''.join(a)
 
     data = list(str(date))
-    if len(data) == 10:
+
+    if len(data) == 16:
+        return f'{_join(data[:4])}-{_join(data[5:7])}-{_join(data[8:10])}'
+    elif len(data) == 10:
         return f'{_join(data[:4])}-{_join(data[4:6])}-{_join(data[6:8])}T{_join(data[8:])}'
     elif len(data) == 8:
         return f'{_join(data[:4])}-{_join(data[4:6])}-{_join(data[6:])}'

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -114,8 +114,14 @@ def parse_cesm_history(file, user_streams_dict={}):
                 info['component'] = stream.component
                 info['stream'] = stream.name
                 z = file.stem.split(extracted_stream)
-                info['case'] = z[0].strip('.')
                 info['date'] = z[-1].strip('.')
+                info['case'] = z[0].strip('.')
+
+                try:
+                    info['member_id'] = info['case'].split('.')[-1]
+
+                except:
+                    info['member_id'] = None
                 break
         with xr.open_dataset(file, chunks={}, decode_times=False) as ds:
             try:

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -178,7 +178,12 @@ def parse_cesm_timeseries(file, user_streams_dict={}):
                     continue
 
                 info['case'] = z[0].strip('.')
-                info['member_id'] = int(info['case'].split('.')[-1])
+
+                try:
+                    info['member_id'] = int(info['case'].split('.')[-1])
+
+                except:
+                    info['member_id'] = None
 
                 # Use the last part to get variable and time info
                 date_and_variable = z[-1].split('.')

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -180,7 +180,7 @@ def parse_cesm_timeseries(file, user_streams_dict={}):
                 info['case'] = z[0].strip('.')
 
                 try:
-                    info['member_id'] = int(info['case'].split('.')[-1])
+                    info['member_id'] = info['case'].split('.')[-1]
 
                 except:
                     info['member_id'] = None
@@ -253,7 +253,7 @@ def parse_smyle(file):
             inits = z[0].split('-')
             init_year = int(inits[0])
             init_month = int(inits[1])
-            member_id = int(z[-1])
+            member_id = z[-1]
             x = case.split(z[0])[0].strip('.').split('.')
             experiment = x[-2]
             grid = x[-1]


### PR DESCRIPTION
While working on a catalog with Dan Marsh, I ran into the following case `b.e21.BWma1850.f09_g17.release-cesm2.1.3.c20200918` where the last part after `g17.` would be the member id, but cannot be split with the typical `.` separator. For now, I added a try except block where if it has an issue with the member id, it inserts None.