### PR TITLE
Update requirements to include dask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ xarray
 pyyaml
 pydantic
 pandas
+dask


### PR DESCRIPTION
Dask is required when loading the data into chunks in `xarray` - we should add it to the requirements