### PR TITLE
Add xarray open kwargs to cesm timeseries and cesm history

### DIFF
--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -99,7 +99,7 @@ def parse_date(date):
     return date
 
 
-def parse_cesm_history(file, user_streams_dict={}):
+def parse_cesm_history(file, user_streams_dict={}, xarray_open_engine='netcdf4'):
     file = pathlib.Path(file)
     info = {}
     # If there are entries for user_streams, edit the dictionary
@@ -126,7 +126,7 @@ def parse_cesm_history(file, user_streams_dict={}):
                 except:
                     info['member_id'] = None
                 break
-        with xr.open_dataset(file, chunks={}, decode_times=False) as ds:
+        with xr.open_dataset(file, chunks={}, engine=xarray_open_engine, decode_times=False) as ds:
             try:
                 time = ds.cf['time'].name
             except KeyError:
@@ -161,7 +161,7 @@ def parse_cesm_history(file, user_streams_dict={}):
         return {INVALID_ASSET: file, TRACEBACK: traceback.format_exc()}
 
 
-def parse_cesm_timeseries(file, user_streams_dict={}):
+def parse_cesm_timeseries(file, user_streams_dict={}, xarray_open_engine='netcdf4'):
     """Parser for CESM Timeseries files"""
     file = pathlib.Path(file)
     info = {}
@@ -204,7 +204,7 @@ def parse_cesm_timeseries(file, user_streams_dict={}):
                 info['end_time'] = parse_date(end_time)
                 info['time_range'] = date_range
                 break
-        with xr.open_dataset(file, chunks={}, decode_times=False) as ds:
+        with xr.open_dataset(file, chunks={}, engine=xarray_open_engine, decode_times=False) as ds:
 
             # Get the long name from dataset
             info['long_name'] = ds[info['variable']].attrs.get('long_name')

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -105,7 +105,7 @@ def parse_cesm_history(file, user_streams_dict={}, xarray_open_kwargs=None):
     if xarray_open_kwargs is None:
         xarray_open_kwargs = _default_kwargs
     else:
-        xarray_open_kwargs.update(_default_kwargs)
+        _default_kwargs.update(xarray_open_kwargs)
 
     file = pathlib.Path(file)
     info = {}
@@ -174,7 +174,8 @@ def parse_cesm_timeseries(file, user_streams_dict={}, xarray_open_kwargs=None):
     if xarray_open_kwargs is None:
         xarray_open_kwargs = _default_kwargs
     else:
-        xarray_open_kwargs.update(_default_kwargs)
+        _default_kwargs.update(xarray_open_kwargs)
+
     file = pathlib.Path(file)
     info = {}
 

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -102,10 +102,10 @@ def parse_date(date):
 def parse_cesm_history(file, user_streams_dict={}, xarray_open_kwargs=None):
   _default_kwargs = {'engine': 'netcdf4', chunks: {}, decode_times=False}
   if xarray_open_kwargs is None:
-     xarray_open_kwargs = _default_kwargs 
+     xarray_open_kwargs = _default_kwargs
    else:
      xarray_open_kwargs.update(_default_kwargs)
-  
+
     file = pathlib.Path(file)
     info = {}
     # If there are entries for user_streams, edit the dictionary

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -132,7 +132,7 @@ def parse_cesm_history(file, user_streams_dict={}, xarray_open_kwargs=None):
                 except:
                     info['member_id'] = None
                 break
-        with xr.open_dataset(file, chunks={}, engine=xarray_open_engine, decode_times=False) as ds:
+        with xr.open_dataset(file, **xarray_open_kwargs) as ds:
             try:
                 time = ds.cf['time'].name
             except KeyError:

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -99,7 +99,13 @@ def parse_date(date):
     return date
 
 
-def parse_cesm_history(file, user_streams_dict={}, xarray_open_engine='netcdf4'):
+def parse_cesm_history(file, user_streams_dict={}, xarray_open_kwargs=None):
+  _default_kwargs = {'engine': 'netcdf4', chunks: {}, decode_times=False}
+  if xarray_open_kwargs is None:
+     xarray_open_kwargs = _default_kwargs 
+   else:
+     xarray_open_kwargs.update(_default_kwargs)
+  
     file = pathlib.Path(file)
     info = {}
     # If there are entries for user_streams, edit the dictionary

--- a/ecgtools/parsers/cesm.py
+++ b/ecgtools/parsers/cesm.py
@@ -100,11 +100,12 @@ def parse_date(date):
 
 
 def parse_cesm_history(file, user_streams_dict={}, xarray_open_kwargs=None):
-  _default_kwargs = {'engine': 'netcdf4', chunks: {}, decode_times=False}
-  if xarray_open_kwargs is None:
-     xarray_open_kwargs = _default_kwargs
-   else:
-     xarray_open_kwargs.update(_default_kwargs)
+    """Parser for CESM history files"""
+    _default_kwargs = {'engine': 'netcdf4', 'chunks': {}, 'decode_times': False}
+    if xarray_open_kwargs is None:
+        xarray_open_kwargs = _default_kwargs
+    else:
+        xarray_open_kwargs.update(_default_kwargs)
 
     file = pathlib.Path(file)
     info = {}
@@ -167,8 +168,13 @@ def parse_cesm_history(file, user_streams_dict={}, xarray_open_kwargs=None):
         return {INVALID_ASSET: file, TRACEBACK: traceback.format_exc()}
 
 
-def parse_cesm_timeseries(file, user_streams_dict={}, xarray_open_engine='netcdf4'):
-    """Parser for CESM Timeseries files"""
+def parse_cesm_timeseries(file, user_streams_dict={}, xarray_open_kwargs=None):
+    """Parser for CESM timeseries files"""
+    _default_kwargs = {'engine': 'netcdf4', 'chunks': {}, 'decode_times': False}
+    if xarray_open_kwargs is None:
+        xarray_open_kwargs = _default_kwargs
+    else:
+        xarray_open_kwargs.update(_default_kwargs)
     file = pathlib.Path(file)
     info = {}
 
@@ -210,7 +216,7 @@ def parse_cesm_timeseries(file, user_streams_dict={}, xarray_open_engine='netcdf
                 info['end_time'] = parse_date(end_time)
                 info['time_range'] = date_range
                 break
-        with xr.open_dataset(file, chunks={}, engine=xarray_open_engine, decode_times=False) as ds:
+        with xr.open_dataset(file, **xarray_open_kwargs) as ds:
 
             # Get the long name from dataset
             info['long_name'] = ds[info['variable']].attrs.get('long_name')


### PR DESCRIPTION
Closes #80 - allows user to specify an engine for reading in the data into `xarray`