### PR TITLE
Add fix for preventing nested list

### DIFF
--- a/ecgtools/builder.py
+++ b/ecgtools/builder.py
@@ -108,11 +108,14 @@ class Builder:
         elif isinstance(self.root_path, list):
             dirs = [x for path in self.root_path for x in path.glob(pattern) if x.is_dir()]
 
-            if not dirs:
+        if not dirs:
+
+            if not isinstance(self.root_path, list):
+                dirs = [self.root_path]
+
+            else:
                 dirs = self.root_path
 
-        if not dirs:
-            dirs = [self.root_path]
         self.dirs = dirs
         return self
 

--- a/ecgtools/builder.py
+++ b/ecgtools/builder.py
@@ -108,6 +108,9 @@ class Builder:
         elif isinstance(self.root_path, list):
             dirs = [x for path in self.root_path for x in path.glob(pattern) if x.is_dir()]
 
+            if not dirs:
+                dirs = self.root_path
+
         if not dirs:
             dirs = [self.root_path]
         self.dirs = dirs

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -35,6 +35,10 @@ def test_root_path_error():
         sample_data_dir / 'cmip' / 'cmip5',
         sample_data_dir / 'cesm',
         [sample_data_dir / 'cmip' / 'CMIP6', sample_data_dir / 'cmip' / 'cmip5'],
+        [
+            sample_data_dir / 'cmip' / 'CMIP6' / 'CMIP' / 'IPSL',
+            sample_data_dir / 'cmip' / 'cmip5' / 'output1' / 'IPSL',
+        ],
     ],
 )
 def test_init(root_path):
@@ -48,6 +52,10 @@ def test_init(root_path):
         sample_data_dir / 'cmip' / 'cmip5',
         sample_data_dir / 'cesm',
         [sample_data_dir / 'cmip' / 'CMIP6', sample_data_dir / 'cmip' / 'cmip5'],
+        [
+            sample_data_dir / 'cmip' / 'CMIP6' / 'CMIP' / 'IPSL',
+            sample_data_dir / 'cmip' / 'cmip5' / 'output1' / 'IPSL',
+        ],
     ],
 )
 def test_get_filelist(root_path):


### PR DESCRIPTION
When building from a list of directories, the current implementation will results in a nested list of the input directories, which causes issues with `get_filelist` - this ensures that this issue does not happen with a provided list of directories