### PR TITLE
fix pydantic requirement to avoid newer version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ joblib
 netCDF4
 xarray
 pyyaml
-pydantic>=2.0
+pydantic>=2.0,<2.12
 pandas
 fsspec
 intake-esm>=2023.7.7


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->



## Change Summary

<!-- Please give a short summary of the changes. -->
pydantic >2.12 will not work with current version on the save method which shows format attribute not exist in the error message. 

## Related issue number
 A issue is created related to this PR #204

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

-

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
